### PR TITLE
Use shared deploy bucket for vendor libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,18 @@ env:
   - TOX_ENV=py36
   - TOX_ENV=coveralls
   - TOX_ENV=flake8
-install:
-  - pip install tox
-script:
-  - tox -e $TOX_ENV
-before_deploy: pip install awscli
-deploy:
-  skip_cleanup: true
-  provider: script
-  script: make stage
+install: pip install tox
+script: tox -e $TOX_ENV
+jobs:
+  include:
+    - name: Build dist
+      before_install: pip install awscli pipenv
+      install: pipenv install
+      script: make dist
+    - stage: deploy
+      before_install: pip install pipenv awscli
+      install: pipenv install
+      script: skip
+      deploy:
+        provider: script
+        script: make stage

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-S3_BUCKET=carbon-deploy
+S3_BUCKET=deploy-mitlib-stage
 ORACLE_ZIP=instantclient-basiclite-linux.x64-18.3.0.0.0dbru.zip
 LIBAIO=libaio.so.1.0.1
 
@@ -14,16 +14,22 @@ lib/libclntsh.so:
   	unzip -j lib/$(ORACLE_ZIP) -d lib/ 'instantclient_18_3/*' && \
   	rm -f lib/$(ORACLE_ZIP)
 
-stage: lib/libclntsh.so lib/libaio.so.1 ## Deploy staging build
+deps: lib/libaio.so.1 lib/libclntsh.so
+
+dist: deps ## Create deploy package locally
+	pipenv run zappa package
+
+stage: deps ## Deploy staging build
 	pipenv run zappa update stage
 
-prod: lib/libclntsh.so lib/libaio.so.1 ## Deploy production build
+prod: deps ## Deploy production build
 	pipenv run zappa update prod
 
 clean: ## Remove build artifacts
 	find . -name "*.pyc" -print0 | xargs -0 rm -f
 	find . -name '__pycache__' -print0 | xargs -0 rm -rf
 	rm -rf .coverage .tox *.egg-info .eggs build/
+	rm -f author-lookup-stage-*.zip
 
 distclean: clean ## Remove build artifacts and vendor libs
 	rm -rf lib/


### PR DESCRIPTION
This changes the build to use the new shared S3 bucket with the required
libraries. It also adds a new dist target for the Makefile. This is
mostly as a sanity check during Travis testing to ferret out any build
problems before a merge.