### PR TITLE
Try removing profile from config

### DIFF
--- a/zappa_settings.json
+++ b/zappa_settings.json
@@ -12,7 +12,6 @@
                     ".pytest_cache", "flake8*", "gunicorn*", "pytest*",
                     "pyflakes*", "coverage*", ".git*", "_pytest*"],
         "manage_roles": false,
-        "profile_name": "default",
         "project_name": "author-lookup",
         "role_arn": "arn:aws:iam::672626379771:role/author-lookup-stage-lambda",
         "runtime": "python3.6",


### PR DESCRIPTION
The CI build is failing during merge to master because the AWS client is
looking for a config file instead of env vars. Removing the profile name
from the settings file may fix this.