### PR TITLE
Set up docker-compose for local dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.7-slim
+
+ENV PIP_NO_CACHE_DIR yes
+ENV LD_LIBRARY_PATH /usr/local/lib
+
+RUN \
+  apt-get update -yqq && \
+  apt-get install -yqq libaio1 && \
+  pip install --upgrade pip pipenv
+
+COPY Pipfile* /
+RUN pipenv install --deploy --system --ignore-pipfile
+COPY lib/* /usr/local/lib/
+COPY dw_lookup /dw_lookup
+
+ENTRYPOINT ["gunicorn"]
+CMD ["-b", "0.0.0.0", "dw_lookup.app:app"]

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,24 @@
 S3_BUCKET=deploy-mitlib-stage
 ORACLE_ZIP=instantclient-basiclite-linux.x64-18.3.0.0.0dbru.zip
-LIBAIO=libaio.so.1.0.1
 
 help: ## Print this message
 	@awk 'BEGIN { FS = ":.*##"; print "Usage:  make <target>\n\nTargets:" } \
 				/^[-_[:alpha:]]+:.?*##/ { printf "  %-15s%s\n", $$1, $$2 }' $(MAKEFILE_LIST)
-
-lib/libaio.so.1:
-	aws s3 cp s3://$(S3_BUCKET)/$(LIBAIO) lib/libaio.so.1
 
 lib/libclntsh.so:
 	aws s3 cp s3://$(S3_BUCKET)/$(ORACLE_ZIP) lib/$(ORACLE_ZIP) && \
   	unzip -j lib/$(ORACLE_ZIP) -d lib/ 'instantclient_18_3/*' && \
   	rm -f lib/$(ORACLE_ZIP)
 
-deps: lib/libaio.so.1 lib/libclntsh.so
+deps: lib/libclntsh.so
 
-dist: deps ## Create stage deploy package locally
-	pipenv run zappa package stage
-
-stage: deps ## Deploy staging build
-	pipenv run zappa update stage
-	pipenv run zappa certify --yes stage
-
-prod: deps ## Deploy production build
-	pipenv run zappa update prod
-	pipenv run zappa certify --yes prod
+dist: deps ## Create docker image
+	docker build -t author_lookup:latest .
 
 clean: ## Remove build artifacts
 	find . -name "*.pyc" -print0 | xargs -0 rm -f
 	find . -name '__pycache__' -print0 | xargs -0 rm -rf
 	rm -rf .coverage .tox *.egg-info .eggs build/
-	rm -f author-lookup-stage-*.zip
 
 distclean: clean ## Remove build artifacts and vendor libs
 	rm -rf lib/

--- a/README.rst
+++ b/README.rst
@@ -4,46 +4,35 @@ Author Lookup
 
 This is the author lookup API used by DSpace for managing people authorties.
 
-.. contents:: Table of Contents
-.. section-numbering::
-
 Developing
 ----------
 
-Use ``pipenv`` to install and manage dependencies::
+Because of the Oracle client library requirement, the recommended way to do local development is to use the provided docker-compose file. You must be connected to the VPN for this to work. You'll need to create a ``.env`` file in the project directory with the following environment variables (ask in the #engineering slack channel for the values)::
 
-  $ git clone git@github.com:MITLibraries/dw_lookup.git
-  $ cd dw_lookup
-  $ pipenv install --dev
+  AUTHOR_DB_USER
+  AUTHOR_DB_PASSWORD
+  AUTHOR_DB_HOST
+  AUTHOR_DB_PORT
+  AUTHOR_DB_SID
 
-In order to connect to the Data Warehouse, you will need to install the `Oracle client library <https://www.oracle.com/technetwork/database/database-technologies/instant-client/overview/index.html>`_. It seems that just installing the basic light package should be fine. In general, all you should need to do is extract the package and add the extracted directory to your ``LD_LIBRARY_PATH`` environment variable. If there is no ``lbclntsh.so`` (``libclntsh.dylib`` for Mac) symlink in the extracted directory, you will need to create one. The process will look something like this (changing for paths/filenames as necessary)::
+Additionally, if you are using Linux you will need to set ``AUTHOR_NETWORK_MODE=host``. The default password for the dev app is ``authortoken``. You can change this by setting ``DW_LOOKUP_TOKEN``.
 
-    $ unzip instantclient-basiclite-linux.x64-18.3.0.0.0dbru.zip -d /usr/local/opt
+You should use make to build the docker image as opposed to running ``docker build`` yourself::
 
-    # Add the following line to your .bash_profile or whatever to make it permanent
-    $ export LD_LIBRARY_PATH=/usr/local/opt/instantclient_18_3:$LD_LIBRARY_PATH
+  $ make dist
+  $ docker-compose up
 
-    # If the symlink doesn't already exist:
-    $ ln -rs /usr/local/opt/instantclient_18_3/libclntsh.so.18.1 \
-        /usr/local/opt/instantclient_18_3/libclntsh.so
-
-On Linux, you will also need to make sure you have libaio installed. You can probably just use your system's package manager to install this easily. The package may be called ``libaio1``.
+Dependencies are managed with ``pipenv``.
 
 Deploying
 ---------
 
-.. IMPORTANT::
-  The deploy process copies *everything* from project root into the Lambda deploy package. Your project root *must* be clean before deploying! In other words, ``git status`` should show no untracked files.
-
-Dependencies
-~~~~~~~~~~~~
-
-The Lambda deploy package needs the Oracle client library and libaio added to it. The make commands for creating a deploy will do this for you. Copies of these two libraries are stored in an S3 bucket. If you need to update the version of either library make sure you are using a version compiled for Linux x86_64 architecture.
+Deployment is handled through Terraform/Ansible. To deploy changes you will need to first create a Github release. Then, update the ``author_version`` variable in the python role of the Ansible config. See `the Terraform repo <https://github.com/MITLibraries/mitlib-terraform>`_ for more details.
 
 Configuration
 ~~~~~~~~~~~~~
 
-The app needs a few environment variables to work. The Lambda deploy gets these from an AWS Secret so it only needs the ``AWS_SECRET_ID`` set to the ARN for a secret containing the following keys:
+The app needs a few environment variables to work. In staging and production these are pulled from an AWS Secret so it only needs the ``AWS_SECRET_ID`` set to the ARN for a secret containing the following keys:
 
 +------------------------+-----------------------------------+
 | Key                    | Description                       |
@@ -60,19 +49,4 @@ The app needs a few environment variables to work. The Lambda deploy gets these 
 +------------------------+-----------------------------------+
 | ``DW_LOOKUP_TOKEN``    | API key needed to authenticate    |
 +------------------------+-----------------------------------+
-
-Deploy
-~~~~~~
-
-This application is deployed as a serverless API Gateway app using `Zappa <https://github.com/Miserlou/Zappa>`_. In general, the process for deploying should be as simple as::
-
-  $ make stage
-
-to deploy a staging build and::
-
-  $ make prod
-
-to deploy a production build.
-
-Zappa `has problems <https://github.com/Miserlou/Zappa/issues/795>`_ sometimes with certain deployments. Setting ``slim_handler`` to ``false`` in the Zappa config seems to prevent this issue from happening. Using this option, however, creates a deploy package that's ~65MB. This is technically over the 50MB limit for Lambda deploy packages, but in practice 65MB seems to be fine. It also wouldn't hurt to run ``make clean`` before deploying.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.7"
+services:
+  web:
+    image: "author_lookup"
+    build: .
+    ports:
+      - "8000:8000"
+    network_mode: "${AUTHOR_NETWORK_MODE:-bridge}"
+    environment:
+      DW_LOOKUP_TOKEN: "${DW_LOOKUP_TOKEN:-authortoken}"
+      AUTHOR_DB_USER: "${AUTHOR_DB_USER}"
+      AUTHOR_DB_PASSWORD: "${AUTHOR_DB_PASSWORD}"
+      AUTHOR_DB_HOST: "${AUTHOR_DB_HOST}"
+      AUTHOR_DB_PORT: 1521
+      AUTHOR_DB_SID: "${AUTHOR_DB_SID}"


### PR DESCRIPTION
This adds docker-compose to make running this in development easier. The
advantage of this approach is the developer will no longer have to
configure their system with the Oracle libraries.